### PR TITLE
Issue #138 - SMS NavBar missing

### DIFF
--- a/Relay/src/AppDelegate.m
+++ b/Relay/src/AppDelegate.m
@@ -74,12 +74,10 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     }
     
     // Navbar background color iOS10 bug workaround
-//    [UINavigationBar appearance].backgroundColor = [UIColor blackColor];
-//    [UINavigationBar appearance].barTintColor = [UIColor blackColor];
-    [[UINavigationBar appearance] setBackgroundImage:[[UIImage alloc] init]
-                                      forBarPosition:UIBarPositionAny
-                                          barMetrics:UIBarMetricsDefault];
-    [[UINavigationBar appearance] setShadowImage:[[UIImage alloc] init]];
+    [UINavigationBar appearance].backgroundColor = [UIColor blackColor];
+    [UINavigationBar appearance].barTintColor = [UIColor blackColor];
+    [UINavigationBar appearance].tintColor = [UIColor whiteColor];
+    [UINavigationBar appearance].translucent = YES;
     
     // Setting up environment
     [Environment setCurrent:[Release releaseEnvironmentWithLogging:logger]];

--- a/Relay/src/view controllers/LoginViewController.m
+++ b/Relay/src/view controllers/LoginViewController.m
@@ -29,6 +29,8 @@
     // Setup nav controller
     self.navigationController.navigationBar.barTintColor = [UIColor whiteColor];
     self.navigationController.navigationBar.tintColor = [UIColor blackColor];
+    [self.navigationController.navigationBar setBackgroundImage:[UIImage new] forBarMetrics:UIBarMetricsDefault];
+    self.navigationController.navigationBar.shadowImage = [UIImage new];
     
     // Do any additional setup after loading the view.
     self.ccsmStorage = [CCSMStorage new];


### PR DESCRIPTION
Put the iOS 10+ navBar workaround back into place for the SMS messaging view.