### PR TITLE
Fix Unnamed Conversation and deadlock crash.

### DIFF
--- a/Forsta.xcodeproj/project.pbxproj
+++ b/Forsta.xcodeproj/project.pbxproj
@@ -6362,7 +6362,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 78;
+				CURRENT_PROJECT_VERSION = 79;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6431,7 +6431,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 78;
+				CURRENT_PROJECT_VERSION = 79;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6498,7 +6498,7 @@
 				CODE_SIGN_ENTITLEMENTS = Relay/RelayStage.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 78;
+				CURRENT_PROJECT_VERSION = 79;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6566,7 +6566,7 @@
 				CODE_SIGN_ENTITLEMENTS = Relay/RelayStage.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 78;
+				CURRENT_PROJECT_VERSION = 79;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6772,7 +6772,7 @@
 				CODE_SIGN_ENTITLEMENTS = Relay/Relay.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 78;
+				CURRENT_PROJECT_VERSION = 79;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6838,7 +6838,7 @@
 				CODE_SIGN_ENTITLEMENTS = Relay/Relay.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 78;
+				CURRENT_PROJECT_VERSION = 79;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/Relay-Info.plist
+++ b/Relay-Info.plist
@@ -40,7 +40,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>78</string>
+	<string>79</string>
 	<key>FLSupermanID</key>
 	<string>cf40fca2-dfa8-4356-8ae7-45f56f7551ca</string>
 	<key>Fabric</key>

--- a/Relay/src/RelayServiceKit/CCSM/FLMessagesManager.m
+++ b/Relay/src/RelayServiceKit/CCSM/FLMessagesManager.m
@@ -86,9 +86,9 @@
                     [self.disappearingMessagesJob becomeConsistentWithConfigurationForMessage:incomingMessage
                                                                               contactsManager:self.contactsManager];
                     
-                    // Update thread preview in inbox
+                    // Update thread
                     [thread touch];
-                    
+
                     // TODO Delay notification by 100ms?
                     // It's pretty annoying when you're phone keeps buzzing while you're having a conversation on Desktop.
                     NSString *name = thread.displayName;

--- a/Relay/src/RelayServiceKit/CCSM/FLTagMathService.h
+++ b/Relay/src/RelayServiceKit/CCSM/FLTagMathService.h
@@ -10,8 +10,10 @@
 @interface FLTagMathService : NSObject
 
 
--(void)tagLookupWithString:(NSString *_Nonnull)lookupString
-                   success:(void (^_Nonnull)(NSDictionary *_Nonnull))successBlock
-                   failure:(void (^_Nonnull)(NSError *_Nonnull))failureBlock;
++(void)asyncTagLookupWithString:(NSString *_Nonnull)lookupString
+                        success:(void (^_Nonnull)(NSDictionary *_Nonnull))successBlock
+                        failure:(void (^_Nonnull)(NSError *_Nonnull))failureBlock;
+
++(NSDictionary *_Nullable)syncTagLookupWithString:(NSString *_Nonnull)lookupString;
 
 @end

--- a/Relay/src/RelayServiceKit/CCSM/FLTagMathService.m
+++ b/Relay/src/RelayServiceKit/CCSM/FLTagMathService.m
@@ -36,21 +36,11 @@
 
 @implementation FLTagMathService
 
--(void)tagLookupWithString:(NSString *_Nonnull)lookupString
-                   success:(void (^_Nonnull)(NSDictionary *_Nonnull))successBlock
-                   failure:(void (^_Nonnull)(NSError *_Nonnull))failureBlock;
++(void)asyncTagLookupWithString:(NSString *_Nonnull)lookupString
+                        success:(void (^_Nonnull)(NSDictionary *_Nonnull))successBlock
+                        failure:(void (^_Nonnull)(NSError *_Nonnull))failureBlock;
 {
-    NSString *sessionToken = [[CCSMStorage new] getSessionToken];
-    NSString *homeURL = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CCSM_Home_URL"];
-
-    NSString *urlString = [NSString stringWithFormat:@"%@%@?expression=%@", homeURL, FLTagMathPath, lookupString];
-    NSURL *url = [NSURL URLWithString:[urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
-    
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
-    [request setHTTPMethod:@"GET"];
-    [request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
-    [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
-    [request addValue:[NSString stringWithFormat:@"JWT %@", sessionToken] forHTTPHeaderField:@"Authorization"];
+    NSMutableURLRequest *request = [self requestForString:lookupString];
     
     [NSURLConnection sendAsynchronousRequest:request
                                        queue:[[NSOperationQueue alloc] init]
@@ -83,4 +73,53 @@
      }];
 }
 
++(NSDictionary *_Nullable)syncTagLookupWithString:(NSString *_Nonnull)lookupString
+{
+    NSMutableURLRequest *request = [self requestForString:lookupString];
+    
+    NSHTTPURLResponse *HTTPresponse;
+    NSError *connectionError;
+    NSData *data = [NSURLConnection sendSynchronousRequest:request
+                                         returningResponse:&HTTPresponse
+                                                     error:&connectionError];
+    
+    DDLogDebug(@"Server response code: %ld", (long)HTTPresponse.statusCode);
+    DDLogDebug(@"%@",[NSHTTPURLResponse localizedStringForStatusCode:HTTPresponse.statusCode]);
+    if (connectionError != nil)  // Failed connection
+    {
+        DDLogDebug(@"Tag Math.  Error: %@", connectionError);
+        return nil;
+    }
+    else if (HTTPresponse.statusCode == 200) // SUCCESS!
+    {
+        return [NSJSONSerialization JSONObjectWithData:data
+                                                               options:0
+                                                                 error:NULL];
+    }
+    else  // Connection good, error from server
+    {
+        NSError *error = [NSError errorWithDomain:NSURLErrorDomain
+                                             code:HTTPresponse.statusCode
+                                         userInfo:@{NSLocalizedDescriptionKey:[NSHTTPURLResponse localizedStringForStatusCode:HTTPresponse.statusCode]}];
+        DDLogDebug(@"Tag Math.  Error: %@", error);
+        return nil;
+    }
+}
+
++(NSMutableURLRequest *)requestForString:(NSString *)lookupString
+{
+    NSString *sessionToken = [[CCSMStorage new] getSessionToken];
+    NSString *homeURL = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CCSM_Home_URL"];
+    
+    NSString *urlString = [NSString stringWithFormat:@"%@%@?expression=%@", homeURL, FLTagMathPath, lookupString];
+    NSURL *url = [NSURL URLWithString:[urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+    
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+    [request setHTTPMethod:@"GET"];
+    [request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+    [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+    [request addValue:[NSString stringWithFormat:@"JWT %@", sessionToken] forHTTPHeaderField:@"Authorization"];
+    
+    return request;
+}
 @end

--- a/Relay/src/RelayServiceKit/Contacts/TSThread.h
+++ b/Relay/src/RelayServiceKit/Contacts/TSThread.h
@@ -171,6 +171,10 @@ NS_ASSUME_NONNULL_BEGIN
 +(instancetype)getOrCreateThreadWithID:(NSString *)threadID;
 +(instancetype)getOrCreateThreadWithID:(NSString *_Nonnull)threadID
                            transaction:(YapDatabaseReadWriteTransaction *)transaction;
+
+/**
+ *  Get or create thread with thread forsta payload
+ */
 +(instancetype)threadWithPayload:(NSDictionary *)payload;
 +(instancetype)threadWithPayload:(NSDictionary *)payload
                      transaction:(YapDatabaseReadWriteTransaction *)transaction;

--- a/Relay/src/RelayServiceKit/Contacts/TSThread.m
+++ b/Relay/src/RelayServiceKit/Contacts/TSThread.m
@@ -127,18 +127,22 @@ static const NSString *FLExpressionKey = @"expression";
     thread.type = ((threadType.length > 0) ? threadType : nil );
     thread.universalExpression = ((threadExpression.length > 0) ? threadExpression : nil );
 
-    dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
-        [[FLTagMathService new] tagLookupWithString:thread.universalExpression
-                                            success:^(NSDictionary *results) {
+    NSDictionary *lookupDict = [FLTagMathService syncTagLookupWithString:thread.universalExpression];
+    if (lookupDict) {
+        thread.participants = [lookupDict objectForKey:@"userids"];
+        thread.prettyExpression = [lookupDict objectForKey:@"pretty"];
+    }
+
+//    dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
+//        [[FLTagMathService new] tagLookupWithString:thread.universalExpression
+//                                            success:^(NSDictionary *results) {
                                                 // thread/message configuration from JSON payload
-                                                thread.participants = [results objectForKey:@"userids"];
-                                                thread.prettyExpression = [results objectForKey:@"pretty"];
-                                                [thread save];
-                                            }
-                                            failure:^(NSError *error) {
-                                                DDLogDebug(@"Tagmath lookup failed during thread generation! Error: %@", error.description);
-                                            }];
-    });
+//                                                [thread save];
+//                                            }
+//                                            failure:^(NSError *error) {
+//                                                DDLogDebug(@"Tagmath lookup failed during thread generation! Error: %@", error.description);
+//                                            }];
+//    });
     [thread saveWithTransaction:transaction];
 
     return thread;

--- a/Relay/src/environment/Environment.m
+++ b/Relay/src/environment/Environment.m
@@ -221,7 +221,7 @@ static Environment *environment = nil;
     });
     
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        [[FLTagMathService new] tagLookupWithString:[NSString stringWithFormat:@"%@+%@", recipient.tagSlug, selfRec.tagSlug]
+        [FLTagMathService asyncTagLookupWithString:[NSString stringWithFormat:@"%@+%@", recipient.tagSlug, selfRec.tagSlug]
                                             success:^(NSDictionary *results) {
 #warning XXX Needs catch for return with no results.
                                                 thread.universalExpression = [results objectForKey:@"universal"];

--- a/Relay/src/view controllers/DeveloperPanelViewController.m
+++ b/Relay/src/view controllers/DeveloperPanelViewController.m
@@ -73,7 +73,7 @@
 -(BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
 {
     if (textField.text.length >= 3) {
-        [self.tagService tagLookupWithString:textField.text
+        [FLTagMathService asyncTagLookupWithString:textField.text
                                      success:^(NSDictionary *results) {
                                          dispatch_async(dispatch_get_main_queue(), ^{
                                              self.outputLabel.text = [NSString stringWithFormat:@"Successful lookup:\n %@", results.description];

--- a/Relay/src/view controllers/FLThreadViewController.m
+++ b/Relay/src/view controllers/FLThreadViewController.m
@@ -103,8 +103,8 @@ NSString *FLUserSelectedFromDirectory = @"FLUserSelectedFromDirectory";
 @property (nonatomic, strong) NSMutableArray *attachmentIDs;
 @property (nonatomic, strong) NSMutableArray *messages;
 
-@property (nonatomic, strong) IBOutlet UISearchController *searchController;
-@property (nonatomic, weak) IBOutlet UILabel *bannerLabel;
+//@property (nonatomic, strong) IBOutlet UISearchController *searchController;
+//@property (nonatomic, weak) IBOutlet UILabel *bannerLabel;
 
 @property (nonatomic, strong) FLDomainViewController *domainTableViewController;
 @property (nonatomic, strong) SettingsPopupMenuViewController *settingsViewController;
@@ -786,6 +786,21 @@ forRowAtIndexPath:(NSIndexPath *)indexPath
                                                                                  withMappings:self.threadMappings];
     }];
     
+    // "Heal" any unnamed conversations which may be in the database.
+    
+    if ([thread.displayName isEqualToString:NSLocalizedString(@"Unnamed converstaion", @"")]) {
+        NSDictionary *lookupDict = [FLTagMathService syncTagLookupWithString:thread.universalExpression];
+        if (lookupDict) {
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
+                [self.editingDbConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+                    thread.participants = [lookupDict objectForKey:@"userids"];
+                    thread.prettyExpression = [lookupDict objectForKey:@"pretty"];
+                    [thread saveWithTransaction:transaction];
+                }];
+            });
+        }
+    }
+    
     return thread;
 }
 
@@ -977,18 +992,18 @@ forRowAtIndexPath:(NSIndexPath *)indexPath
     return _settingsViewController;
 }
 
--(UISearchController *)searchController
-{
-    if (_searchController == nil) {
-        _searchController = [[UISearchController alloc] initWithSearchResultsController:nil];
-        self.searchController.searchResultsUpdater = self;
-        self.searchController.dimsBackgroundDuringPresentation = NO;
-        self.searchController.hidesNavigationBarDuringPresentation = NO;
-
-        _searchController.delegate = self;
-    }
-    return _searchController;
-}
+//-(UISearchController *)searchController
+//{
+//    if (_searchController == nil) {
+//        _searchController = [[UISearchController alloc] initWithSearchResultsController:nil];
+//        self.searchController.searchResultsUpdater = self;
+//        self.searchController.dimsBackgroundDuringPresentation = NO;
+//        self.searchController.hidesNavigationBarDuringPresentation = NO;
+//
+//        _searchController.delegate = self;
+//    }
+//    return _searchController;
+//}
 
 //-(UISwipeGestureRecognizer *)rightSwipeRecognizer
 //{

--- a/Relay/src/view controllers/InboxTableViewCell.m
+++ b/Relay/src/view controllers/InboxTableViewCell.m
@@ -53,6 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
             self.hidden = YES;
         });
     }
+    
     dispatch_async(dispatch_get_main_queue(), ^{
         
         NSString *name = thread.displayName;

--- a/Relay/src/view controllers/NewGroupViewController.m
+++ b/Relay/src/view controllers/NewGroupViewController.m
@@ -154,7 +154,7 @@ static NSString *const kUnwindToMessagesViewSegue = @"UnwindToMessagesViewSegue"
         }
     }
     
-    [[FLTagMathService new] tagLookupWithString:searchString
+    [FLTagMathService asyncTagLookupWithString:searchString
                                         success:^(NSDictionary *results) {
                                             self.thread = [TSThread getOrCreateThreadWithID:[[NSUUID UUID] UUIDString]];
                                             self.thread.name = model.groupName;

--- a/Relay/src/view controllers/ThreadCreationViewController.m
+++ b/Relay/src/view controllers/ThreadCreationViewController.m
@@ -37,8 +37,6 @@
 @property (nonatomic, strong) NSArray *content;
 @property (nonatomic, strong) NSArray *searchResults;
 
-@property (nonatomic, strong) FLTagMathService *tagService;
-
 @end
 
 @implementation ThreadCreationViewController
@@ -46,7 +44,6 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     // Do any additional setup after loading the view.
-    [self tagService];
 //    [self downSwipeRecognizer];
     self.slugViewHeight.constant = KMinInputHeight;
 //    self.slugContainerView.layoutManager.delegate = self;
@@ -217,7 +214,7 @@
         }
         
         // Do the lookup
-        [self.tagService tagLookupWithString:searchText
+        [FLTagMathService asyncTagLookupWithString:searchText
                                      success:^(NSDictionary *results) {
                                          DDLogDebug(@"%@", results);
                                          NSString *pretty = [results objectForKey:@"pretty"];
@@ -320,7 +317,7 @@
                 [threadSlugs appendFormat:@" + %@", slug];
             }
         }
-        [self.tagService tagLookupWithString:threadSlugs
+        [FLTagMathService asyncTagLookupWithString:threadSlugs
                                      success:^(NSDictionary *results) {
                                          [self buildThreadWithResults:results];
                                      }
@@ -374,7 +371,7 @@
         // add self run again
         NSMutableString *pretty = [[results objectForKey:@"pretty"] mutableCopy];
         [pretty appendFormat:@" + @%@", TSAccountManager.sharedInstance.myself.tagSlug];
-        [self.tagService tagLookupWithString:pretty
+        [FLTagMathService asyncTagLookupWithString:pretty
                                      success:^(NSDictionary *newResults){
                                          [self buildThreadWithResults:newResults];
                                      }
@@ -575,14 +572,6 @@
     } else {
         return nil;
     }
-}
-
--(FLTagMathService *)tagService
-{
-    if (_tagService == nil) {
-        _tagService = [FLTagMathService new];
-    }
-    return _tagService;
 }
 
 @end

--- a/Relay/test/Supporting Files/SignalTests-Info.plist
+++ b/Relay/test/Supporting Files/SignalTests-Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>78</string>
+	<string>79</string>
 </dict>
 </plist>

--- a/RelayDev-Info.plist
+++ b/RelayDev-Info.plist
@@ -40,7 +40,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>78</string>
+	<string>79</string>
 	<key>FLSupermanID</key>
 	<string>1e1116aa-31b3-4fb2-a4db-21e8136d4f3a</string>
 	<key>Fabric</key>

--- a/RelayStage-Info.plist
+++ b/RelayStage-Info.plist
@@ -40,7 +40,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>78</string>
+	<string>79</string>
 	<key>FLSupermanID</key>
 	<string>88e7165e-d2da-4c3f-a14a-bb802bb0cefb</string>
 	<key>Fabric</key>


### PR DESCRIPTION
* Switched FLTagMathService methods to class methods.Added synchronous TagMath lookup method.
* Restructured tagMathLookups to more thoroughly ensure "Unnamed Conversation" threads don't persist.
