### PR TITLE
Bad tag crash bug

### DIFF
--- a/Forsta.xcodeproj/project.pbxproj
+++ b/Forsta.xcodeproj/project.pbxproj
@@ -6451,7 +6451,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 111;
+				CURRENT_PROJECT_VERSION = 112;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6520,7 +6520,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 111;
+				CURRENT_PROJECT_VERSION = 112;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6587,7 +6587,7 @@
 				CODE_SIGN_ENTITLEMENTS = Relay/RelayStage.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 111;
+				CURRENT_PROJECT_VERSION = 112;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6655,7 +6655,7 @@
 				CODE_SIGN_ENTITLEMENTS = Relay/RelayStage.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 111;
+				CURRENT_PROJECT_VERSION = 112;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6861,7 +6861,7 @@
 				CODE_SIGN_ENTITLEMENTS = Relay/Relay.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 111;
+				CURRENT_PROJECT_VERSION = 112;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6927,7 +6927,7 @@
 				CODE_SIGN_ENTITLEMENTS = Relay/Relay.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 111;
+				CURRENT_PROJECT_VERSION = 112;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/Relay-Info.plist
+++ b/Relay-Info.plist
@@ -40,7 +40,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>111</string>
+	<string>112</string>
 	<key>FLSupermanID</key>
 	<string>cf40fca2-dfa8-4356-8ae7-45f56f7551ca</string>
 	<key>Fabric</key>

--- a/Relay/src/RelayServiceKit/Contacts/SignalRecipient.m
+++ b/Relay/src/RelayServiceKit/Contacts/SignalRecipient.m
@@ -92,8 +92,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 +(instancetype)recipientForUserDict:(NSDictionary *)userDict;
 {
-#warning XXX save all the things here
-    NSDictionary *tagDict = [userDict objectForKey:@"tag"];
     SignalRecipient *recipient = [[SignalRecipient alloc] initWithTextSecureIdentifier:[userDict objectForKey:@"id"]
                                                                              firstName:[userDict objectForKey:@"first_name"]
                                                                               lastName:[userDict objectForKey:@"last_name"]];
@@ -104,18 +102,22 @@ NS_ASSUME_NONNULL_BEGIN
     if (orgDict) {
         recipient.orgID = [orgDict objectForKey:@"id"];
         recipient.orgSlug = [orgDict objectForKey:@"slug"];
+    } else {
+        DDLogDebug(@"Missing orgDictionary for Recipient: %@", recipient);
     }
     
-    recipient.flTag = [FLTag tagWithTagDictionary:tagDict];
-    if (recipient.flTag.tagDescription.length == 0) {
-        recipient.flTag.tagDescription = recipient.fullName;
+    NSDictionary *tagDict = [userDict objectForKey:@"tag"];
+    if (tagDict) {
+        recipient.flTag = [FLTag tagWithTagDictionary:tagDict];
+        if (recipient.flTag.tagDescription.length == 0) {
+            recipient.flTag.tagDescription = recipient.fullName;
+        }
+        if (recipient.flTag.orgSlug.length == 0) {
+            recipient.flTag.orgSlug = recipient.orgSlug;
+        }
+    } else {
+        DDLogDebug(@"Missing tagDictionary for Recipient: %@", recipient);
     }
-    if (recipient.flTag.orgSlug.length == 0) {
-        recipient.flTag.orgSlug = recipient.orgSlug;
-    }
-//    recipient.tagID = (tagDict ? [tagDict objectForKey:@"id"] : nil);
-    
-    
     return recipient;
 }
 

--- a/Relay/src/contact/FLContactsManager.m
+++ b/Relay/src/contact/FLContactsManager.m
@@ -229,22 +229,20 @@ typedef BOOL (^ContactSearchBlock)(id, NSUInteger, BOOL *);
 
 -(SignalRecipient *)recipientWithUserID:(NSString *)userID
 {
-    __block SignalRecipient *recipient = nil;
-    
+    // Check to see if we already it locally
     for (SignalRecipient *contact in self.allRecipients) {
         if ([contact.uniqueId isEqualToString:userID]) {
             return contact;
         }
     }
     
-    if (!recipient) {
-        recipient = [CCSMCommManager recipientFromCCSMWithID:userID];
+    // If not, go get it, build it, and save it.
+    SignalRecipient *recipient = [CCSMCommManager recipientFromCCSMWithID:userID];
+    if (recipient) {
         [self saveRecipient:recipient];
-        
-        return recipient;
     }
     
-    return nil;
+    return recipient;
 }
 
 - (SignalRecipient *)latestRecipientForPhoneNumber:(PhoneNumber *)phoneNumber
@@ -366,6 +364,7 @@ typedef BOOL (^ContactSearchBlock)(id, NSUInteger, BOOL *);
 -(NSSet *)identifiersForTagSlug:(NSString *)tagSlug
 {
     // TODO: BUILD THIS!
+    return [NSSet new];
 }
 
 #pragma mark - Logging

--- a/Relay/src/contact/FLTag.m
+++ b/Relay/src/contact/FLTag.m
@@ -18,18 +18,23 @@
 
 +(instancetype _Nullable )tagWithTagDictionary:(NSDictionary *_Nonnull)tagDictionary
 {
-    NSString *tagId = [tagDictionary objectForKey:@"id"];
-    FLTag *newTag = [[FLTag alloc] initWithUniqueId:tagId];
-    newTag.url = [tagDictionary objectForKey:@"url"];
-    newTag.tagDescription = [tagDictionary objectForKey:@"description"];
-    newTag.slug = [tagDictionary objectForKey:@"slug"];
-    NSDictionary *orgDict = [tagDictionary objectForKey:@"org"];
-    if (orgDict) {
-        newTag.orgSlug = [orgDict objectForKey:@"slug"];
-        newTag.orgUrl = [orgDict objectForKey:@"url"];
+    if ([tagDictionary respondsToSelector:@selector(objectForKey:)]) {
+        NSString *tagId = [tagDictionary objectForKey:@"id"];
+        FLTag *newTag = [[FLTag alloc] initWithUniqueId:tagId];
+        newTag.url = [tagDictionary objectForKey:@"url"];
+        newTag.tagDescription = [tagDictionary objectForKey:@"description"];
+        newTag.slug = [tagDictionary objectForKey:@"slug"];
+        NSDictionary *orgDict = [tagDictionary objectForKey:@"org"];
+        if (orgDict) {
+            newTag.orgSlug = [orgDict objectForKey:@"slug"];
+            newTag.orgUrl = [orgDict objectForKey:@"url"];
+        }
+        
+        return newTag;
+    }else {
+        DDLogDebug(@"tagWithTagDictionary called with bad input: %@", tagDictionary);
+        return nil;
     }
-    
-    return newTag;
 }
 
 + (NSString *)collection

--- a/Relay/test/Supporting Files/SignalTests-Info.plist
+++ b/Relay/test/Supporting Files/SignalTests-Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>111</string>
+	<string>112</string>
 </dict>
 </plist>

--- a/RelayDev-Info.plist
+++ b/RelayDev-Info.plist
@@ -40,7 +40,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>111</string>
+	<string>112</string>
 	<key>FLSupermanID</key>
 	<string>1e1116aa-31b3-4fb2-a4db-21e8136d4f3a</string>
 	<key>Fabric</key>

--- a/RelayStage-Info.plist
+++ b/RelayStage-Info.plist
@@ -40,7 +40,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>111</string>
+	<string>112</string>
 	<key>FLSupermanID</key>
 	<string>88e7165e-d2da-4c3f-a14a-bb802bb0cefb</string>
 	<key>Fabric</key>


### PR DESCRIPTION
Fix for crash on attempt to initialize FLTag and SignalRecipients with badly formed dictionaries.

Added nil value check and debug log entries to handle them more gracefully.