### PR TITLE
Lost attachments from web-client

### DIFF
--- a/Forsta.xcodeproj/project.pbxproj
+++ b/Forsta.xcodeproj/project.pbxproj
@@ -6451,7 +6451,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 113;
+				CURRENT_PROJECT_VERSION = 114;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6520,7 +6520,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 113;
+				CURRENT_PROJECT_VERSION = 114;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6587,7 +6587,7 @@
 				CODE_SIGN_ENTITLEMENTS = Relay/RelayStage.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 113;
+				CURRENT_PROJECT_VERSION = 114;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6655,7 +6655,7 @@
 				CODE_SIGN_ENTITLEMENTS = Relay/RelayStage.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 113;
+				CURRENT_PROJECT_VERSION = 114;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6861,7 +6861,7 @@
 				CODE_SIGN_ENTITLEMENTS = Relay/Relay.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 113;
+				CURRENT_PROJECT_VERSION = 114;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6927,7 +6927,7 @@
 				CODE_SIGN_ENTITLEMENTS = Relay/Relay.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 113;
+				CURRENT_PROJECT_VERSION = 114;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ abstract_target 'Common' do
     pod 'PastelogKit',                 '~> 1.3'
     pod 'FFCircularProgressView',      '~> 0.5'
     pod 'SCWaveformView',              '~> 1.0'
-    pod 'ZXingObjC',                   '~> 3.1.0'
+    pod 'ZXingObjC',                   '~> 3.2.2'
     pod 'DJWActionSheet',              '~> 1.0.4'
     pod 'JSQMessagesViewController',   git: 'git@github.com:ForstaLabs/JSQMessagesViewController.git', branch: '7.3.4-attributedText'
     pod '25519',                       '~> 2.0.2'

--- a/Relay-Info.plist
+++ b/Relay-Info.plist
@@ -40,7 +40,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>113</string>
+	<string>114</string>
 	<key>FLSupermanID</key>
 	<string>cf40fca2-dfa8-4356-8ae7-45f56f7551ca</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/Relay/src/Models/TSMessageAdapaters/TSMessageAdapter.m
+++ b/Relay/src/Models/TSMessageAdapaters/TSMessageAdapter.m
@@ -172,7 +172,7 @@
         return [[OWSCall alloc] initWithCallRecord:callRecord];
     } else if ([interaction isKindOfClass:[TSInfoMessage class]]) {
         TSInfoMessage *infoMessage = (TSInfoMessage *)interaction;
-        adapter.infoMessageType    = infoMessage.messageType;
+        adapter.infoMessageType    = (TSInfoMessageType)infoMessage.messageType;
         adapter.messageBody        = infoMessage.description;
         adapter.messageType        = TSInfoMessageAdapter;
         if (adapter.infoMessageType == TSInfoMessageTypeConversationQuit ||

--- a/Relay/src/RelayServiceKit/Messages/Interactions/TSMessage.h
+++ b/Relay/src/RelayServiceKit/Messages/Interactions/TSMessage.h
@@ -35,6 +35,7 @@ typedef NS_ENUM(NSInteger, TSGroupMetaMessage) {
 @property (nonatomic, readonly) uint64_t expiresAt;
 @property (nonatomic, readonly) BOOL isExpiringMessage;
 @property (nonatomic, readonly) BOOL shouldStartExpireTimer;
+@property BOOL hasAnnotation;
 
 - (instancetype)initWithTimestamp:(uint64_t)timestamp;
 

--- a/Relay/src/RelayServiceKit/Messages/TSMessagesManager.m
+++ b/Relay/src/RelayServiceKit/Messages/TSMessagesManager.m
@@ -665,21 +665,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                                  inThread:thread
                                                                                  authorId:envelope.source
                                                                               messageBody:@""];
-            textMessage.forstaPayload = incomingMessage.forstaPayload;
-            textMessage.plainTextBody = incomingMessage.plainTextBody;
-            textMessage.expiresInSeconds = dataMessage.expireTimer;
-            [textMessage saveWithTransaction:transaction];
-        }
-        
-        // Android allows attachments to be sent with body.
-        if ([attachmentIds count] > 0 && incomingMessage.plainTextBody.length > 0) {
-            // We want the text to be displayed under the attachment
-            uint64_t textMessageTimestamp = envelope.timestamp + 1;
-            TSIncomingMessage *textMessage = [[TSIncomingMessage alloc] initWithTimestamp:textMessageTimestamp
-                                                                                 inThread:thread
-                                                                                 authorId:envelope.source
-                                                                              messageBody:@""];
-            textMessage.forstaPayload = incomingMessage.forstaPayload;
+//            textMessage.forstaPayload = incomingMessage.forstaPayload;
             textMessage.plainTextBody = incomingMessage.plainTextBody;
             textMessage.expiresInSeconds = dataMessage.expireTimer;
             [textMessage saveWithTransaction:transaction];

--- a/Relay/src/RelayServiceKit/Messages/TSMessagesManager.m
+++ b/Relay/src/RelayServiceKit/Messages/TSMessagesManager.m
@@ -655,10 +655,10 @@ NS_ASSUME_NONNULL_BEGIN
             incomingMessage.messageType = [jsonPayload objectForKey:@"messageType"];
         }
         incomingMessage.forstaPayload = [jsonPayload mutableCopy];
-        [incomingMessage saveWithTransaction:transaction];
         
-        // Android allows attachments to be sent with body.
-        if ([attachmentIds count] > 0 && incomingMessage.plainTextBody.length > 0) {
+        // Android & web client allow attachments to be sent with body.
+        if (attachmentIds.count > 0 && incomingMessage.plainTextBody.length > 0) {
+            incomingMessage.hasAnnotation = YES;
             // We want the text to be displayed under the attachment
             uint64_t textMessageTimestamp = envelope.timestamp + 1;
             TSIncomingMessage *textMessage = [[TSIncomingMessage alloc] initWithTimestamp:textMessageTimestamp
@@ -670,6 +670,7 @@ NS_ASSUME_NONNULL_BEGIN
             textMessage.expiresInSeconds = dataMessage.expireTimer;
             [textMessage saveWithTransaction:transaction];
         }
+        [incomingMessage saveWithTransaction:transaction];
     }];
     
     if (incomingMessage && thread) {

--- a/Relay/src/view controllers/MessagesViewController.m
+++ b/Relay/src/view controllers/MessagesViewController.m
@@ -1025,12 +1025,13 @@ typedef enum : NSUInteger {
         }
     } else if (message.messageType == TSIncomingMessageAdapter) {
         TSIncomingMessage *incomingMessage = (TSIncomingMessage *)message.interaction;
-        NSString *_Nonnull name = [self.contactsManager nameStringForContactID:incomingMessage.authorId];
-        NSAttributedString *senderNameString = [[NSAttributedString alloc] initWithString:name];
-
-        return senderNameString;
+        if (!incomingMessage.hasAnnotation) {
+            NSString *_Nonnull name = [self.contactsManager nameStringForContactID:incomingMessage.authorId];
+            NSAttributedString *senderNameString = [[NSAttributedString alloc] initWithString:name];
+            
+            return senderNameString;
+        }
     }
-
     return nil;
 }
 

--- a/Relay/test/Supporting Files/SignalTests-Info.plist
+++ b/Relay/test/Supporting Files/SignalTests-Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>113</string>
+	<string>114</string>
 </dict>
 </plist>

--- a/RelayDev-Info.plist
+++ b/RelayDev-Info.plist
@@ -40,7 +40,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>113</string>
+	<string>114</string>
 	<key>FLSupermanID</key>
 	<string>1e1116aa-31b3-4fb2-a4db-21e8136d4f3a</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/RelayStage-Info.plist
+++ b/RelayStage-Info.plist
@@ -40,7 +40,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>113</string>
+	<string>114</string>
 	<key>FLSupermanID</key>
 	<string>88e7165e-d2da-4c3f-a14a-bb802bb0cefb</string>
 	<key>ITSAppUsesNonExemptEncryption</key>


### PR DESCRIPTION
* Fix for attachments getting lost when sent from web client with text annotation.  Remove duplicate code and the payload from the text portion of the message to prevent the database stomp behind the lost attachment.