### PR TITLE
Nil tag crash

### DIFF
--- a/Forsta.xcodeproj/project.pbxproj
+++ b/Forsta.xcodeproj/project.pbxproj
@@ -6524,7 +6524,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 216;
+				CURRENT_PROJECT_VERSION = 217;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6594,7 +6594,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 216;
+				CURRENT_PROJECT_VERSION = 217;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6662,7 +6662,7 @@
 				CODE_SIGN_ENTITLEMENTS = Relay/RelayStage.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 216;
+				CURRENT_PROJECT_VERSION = 217;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6730,7 +6730,7 @@
 				CODE_SIGN_ENTITLEMENTS = Relay/RelayStage.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 216;
+				CURRENT_PROJECT_VERSION = 217;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6936,7 +6936,7 @@
 				CODE_SIGN_ENTITLEMENTS = Relay/Relay.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 216;
+				CURRENT_PROJECT_VERSION = 217;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -7002,7 +7002,7 @@
 				CODE_SIGN_ENTITLEMENTS = Relay/Relay.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 216;
+				CURRENT_PROJECT_VERSION = 217;
 				DEVELOPMENT_TEAM = THHR8L4QV3;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/Relay-Info.plist
+++ b/Relay-Info.plist
@@ -40,7 +40,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>216</string>
+	<string>217</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LOGS_EMAIL</key>

--- a/Relay/src/contact/FLContactsManager.m
+++ b/Relay/src/contact/FLContactsManager.m
@@ -325,7 +325,8 @@ typedef BOOL (^ContactSearchBlock)(id, NSUInteger, BOOL *);
     
     recipient.isActive = ([(NSNumber *)[userDict objectForKey:@"is_active"] intValue] == 1 ? YES : NO);
     if (!recipient.isActive) {
-        [Environment.getCurrent.contactsManager removeRecipient:recipient withTransaction:transaction];
+        DDLogInfo(@"Removing inactive user: %@", uid);
+        [self removeRecipient:recipient withTransaction:transaction];
         return nil;
     }
     
@@ -355,15 +356,16 @@ typedef BOOL (^ContactSearchBlock)(id, NSUInteger, BOOL *);
             recipient.flTag.orgSlug = recipient.orgSlug;
         }
         if (recipient.flTag == nil) {
-            DDLogError(@"Recipient created with a nil tag!  Recipient: %@", recipient);
+            DDLogError(@"Attempt to create recipient with a nil tag!  Recipient: %@", recipient);
+            [self removeRecipient:recipient withTransaction:transaction];
+            return nil;
         } else {
-            [self saveTag:recipient.flTag withTransaction:transaction];
+            [self saveRecipient:recipient withTransaction:transaction];
         }
     } else {
         DDLogDebug(@"Missing tagDictionary for Recipient: %@", self);
     }
 
-    [self saveRecipient:recipient withTransaction:transaction];
     
     return recipient;
 }

--- a/Relay/src/contact/FLContactsManager.m
+++ b/Relay/src/contact/FLContactsManager.m
@@ -156,8 +156,7 @@ typedef BOOL (^ContactSearchBlock)(id, NSUInteger, BOOL *);
     if (recipient.uniqueId.length > 0) {
         [self.recipientCache setObject:recipient forKey:recipient.uniqueId];
         if (recipient.flTag) {
-            [recipient.flTag saveWithTransaction:transaction];
-            [self.tagCache setObject:recipient.flTag forKey:recipient.flTag.uniqueId];
+            [self saveTag:recipient.flTag withTransaction:transaction];
         }
         [recipient saveWithTransaction:transaction];
         [self.recipientCache setObject:recipient forKey:recipient.uniqueId];

--- a/Relay/src/contact/FLContactsManager.m
+++ b/Relay/src/contact/FLContactsManager.m
@@ -355,7 +355,11 @@ typedef BOOL (^ContactSearchBlock)(id, NSUInteger, BOOL *);
         if (recipient.flTag.orgSlug.length == 0) {
             recipient.flTag.orgSlug = recipient.orgSlug;
         }
-        [self saveTag:recipient.flTag withTransaction:transaction];
+        if (recipient.flTag == nil) {
+            DDLogError(@"Recipient created with a nil tag!  Recipient: %@", recipient);
+        } else {
+            [self saveTag:recipient.flTag withTransaction:transaction];
+        }
     } else {
         DDLogDebug(@"Missing tagDictionary for Recipient: %@", self);
     }

--- a/Relay/test/Supporting Files/SignalTests-Info.plist
+++ b/Relay/test/Supporting Files/SignalTests-Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>216</string>
+	<string>217</string>
 </dict>
 </plist>

--- a/RelayDev-Info.plist
+++ b/RelayDev-Info.plist
@@ -40,7 +40,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>216</string>
+	<string>217</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LOGS_EMAIL</key>

--- a/RelayStage-Info.plist
+++ b/RelayStage-Info.plist
@@ -40,7 +40,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>216</string>
+	<string>217</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LOGS_EMAIL</key>


### PR DESCRIPTION
* Added check to recipient creation to defend against nil tags from malformed recipients.
* Forced ContactsManager to use its own saveTag method.